### PR TITLE
fixed label alignment when scaled

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -97,6 +97,11 @@ label {
     color: var(--main-color);
 }
 
+.label-align {
+    margin: auto;
+    text-align: center;
+}
+
 input, input.select-dropdown{
     border-bottom: var(--white-border) !important;
     text-align: center;

--- a/index.html
+++ b/index.html
@@ -39,19 +39,19 @@
                     </div>
 
                     <div class="row">
-                        <div class="input-field col s8 offset-s2">
+                        <div class="input-field col s12 m8 offset-m2">
                             <!--the below <i> elements toggle icons on the input line-->
                             <!-- <i class="material-icons prefix">my_location</i> -->
                             <input id="zipcode" type="number" class="validate">
-                            <div class="row">
-                                <label class='col s4 offset-s4 valign center' for="timer">zip</label>
+                            <div class="row label-align">
+                                <label class='valign center' for="timer">zip</label>
                             </div>
                             <span class="helper-text" data-error="" data-success=""></span>
                         </div>
                     </div>
 
                     <div class="row">
-                        <div class="input-field col s8 offset-s2">
+                        <div class="input-field col s12 m8 offset-m2">
                             <!-- <i class="material-icons prefix">explore</i> -->
                             <select class='orange'>
                                 <option value="" disabled selected></option>
@@ -62,8 +62,8 @@
                                 <option value="5">5 miles</option>
                             </select>
                             <label></label>
-                            <div class='row'>
-                                <label for="radius" class="col s4 offset-s4 valign center">radius</label>
+                            <div class='row label-align'>
+                                <label for="radius" class="valign center">radius</label>
                             </div>
                             <span class="helper-text" data-error="wrong" data-success="right"></span>
                             <div class="row">


### PR DESCRIPTION
The labels now scale properly. I added a class to the label's row called 'label-align'. 
Styled said class with: 
margin: auto 
text-align: center

I also used additional column properties for the two inputs. When the screen is small, the columns will be scaled across with s12. However, when the screen size is medium or larger, the columns change to m8, giving it breathing space in the card.  I thought that was prettier to look at on a desktop view instead of a massive input field spanning across my 2k monitor. 

